### PR TITLE
Fix mobile session persistence by enabling remember-me cookies

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -31,6 +31,14 @@ class Config:
     # Session lifetime: 31 days for "remember me" functionality
     PERMANENT_SESSION_LIFETIME = timedelta(days=31)
 
+    # =========================================================================
+    # Remember Me Cookie (Flask-Login persistent authentication)
+    # =========================================================================
+    REMEMBER_COOKIE_DURATION = timedelta(days=31)
+    REMEMBER_COOKIE_SECURE = not DEV_MODE
+    REMEMBER_COOKIE_HTTPONLY = True
+    REMEMBER_COOKIE_SAMESITE = 'Lax'
+
     # Database configuration
     # URL has to be in certain format for render
     uri = os.environ.get("DATABASE_URL")

--- a/backend/routes_v2/api_auth/routes.py
+++ b/backend/routes_v2/api_auth/routes.py
@@ -76,7 +76,7 @@ def api_login():
         # Check if user exists and password is correct
         if user and user.check_password(password):
             # Log the user in (creates Flask-Login session)
-            login_user(user)
+            login_user(user, remember=True)
 
             # Return success with user data
             return jsonify({
@@ -467,7 +467,7 @@ def complete_account():
         db.session.commit()
 
         # Log the user in
-        login_user(user)
+        login_user(user, remember=True)
 
         return jsonify({
             'success': True,
@@ -617,7 +617,7 @@ def reset_password():
     # if send_password_reset_confirmation(user.email):
     #     return jsonify({'message': 'Password reset successful'}), 200
 
-    login_user(user)
+    login_user(user, remember=True)
 
     return jsonify({'message': 'Password reset successful'}), 200
 


### PR DESCRIPTION
Mobile OSes aggressively kill backgrounded processes, destroying session cookies and forcing users to re-login. Adding remember=True to all login paths creates a persistent remember_token cookie alongside the session.